### PR TITLE
update handle when ParseMarkdown fail

### DIFF
--- a/build.go
+++ b/build.go
@@ -82,7 +82,11 @@ func Build() {
 		fileExt := strings.ToLower(filepath.Ext(path))
 		if fileExt == ".md" {
 			// Parse markdown data
-			article := ParseMarkdown(path)
+			article, err := ParseMarkdown(path)
+			if err != nil {
+				Log(err)
+				return err
+			}
 			if article.Draft {
 				return nil
 			}
@@ -92,7 +96,7 @@ func Build() {
 			// Generate directory
 			unixTime := time.Unix(article.Date, 0)
 			directory := unixTime.Format("post/2006/01/02/")
-			err := os.MkdirAll(filepath.Join(publicPath, directory), 0777)
+			err = os.MkdirAll(filepath.Join(publicPath, directory), 0777)
 			if err != nil {
 				Fatal(err.Error())
 			}

--- a/parse.go
+++ b/parse.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"github.com/InkProject/blackfriday"
 	"gopkg.in/yaml.v2"
 	"html/template"
@@ -89,7 +90,7 @@ func ParseConfig(configPath string) *GlobalConfig {
 	return config
 }
 
-func ParseMarkdown(markdownPath string) *Article {
+func ParseMarkdown(markdownPath string) (*Article, error) {
 	var (
 		config      *ArticleConfig
 		configStr   string
@@ -98,7 +99,7 @@ func ParseMarkdown(markdownPath string) *Article {
 	// Read data from file
 	data, err := ioutil.ReadFile(markdownPath)
 	if err != nil {
-		Fatal(err.Error())
+		return nil, err
 	}
 	// Split config and markdown
 	contentStr := string(data)
@@ -113,10 +114,10 @@ func ParseMarkdown(markdownPath string) *Article {
 	}
 	// Parse config content
 	if err := yaml.Unmarshal([]byte(configStr), &config); err != nil {
-		Fatal(err.Error())
+		return nil, err
 	}
 	if config == nil {
-		Fatal("Article config parse error")
+		return nil, errors.New("Article config parse error")
 	}
 	var article Article
 	// Parse preview splited by MORE_SPLIT
@@ -144,5 +145,5 @@ func ParseMarkdown(markdownPath string) *Article {
 	article.Tags = config.Tags
 	article.Topic = config.Topic
 	article.Draft = config.Draft
-	return &article
+	return &article, nil
 }


### PR DESCRIPTION
在ParseMarkdown失败时，Fatal将直接退出程序。
作为后台服务应该一直运行，修改为报错但不退出程序