### PR TITLE
jekyll convert: categories, terminate newline, and md extension name

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,8 +238,12 @@ func Convert(c *cli.Context) {
 				Fatal(err.Error())
 			}
 			inkConfigStr := string(inkConfig)
-			markdownStr := inkConfigStr + "\n\n---\n\n" + contentStr
-			ioutil.WriteFile(filepath.Join(rootPath, "source/"+fileName+".md"), []byte(markdownStr), 0666)
+			markdownStr := inkConfigStr + "\n\n---\n\n" + contentStr + "\n"
+			targetName := "source/" + fileName
+			if fileExt != ".md" {
+				targetName = targetName + ".md"
+			}
+			ioutil.WriteFile(filepath.Join(rootPath, targetName), []byte(markdownStr), 0644)
 			count++
 		}
 		return nil

--- a/main.go
+++ b/main.go
@@ -217,6 +217,15 @@ func Convert(c *cli.Context) {
 			if err = yaml.Unmarshal([]byte(configStr), &article); err != nil {
 				Fatal(err.Error())
 			}
+			tags := make(map[string]bool)
+			for _, t := range article.Tags {
+				tags[t] = true
+			}
+			for _, c := range article.Categories {
+				if _, ok := tags[c]; !ok {
+					article.Tags = append(article.Tags, c)
+				}
+			}
 			if article.Author == "" {
 				article.Author = "me"
 			}

--- a/parse.go
+++ b/parse.go
@@ -43,15 +43,16 @@ type GlobalConfig struct {
 }
 
 type ArticleConfig struct {
-	Title   string
-	Date    string
-	Update  string
-	Author  string
-	Tags    []string
-	Topic   string
-	Draft   bool
-	Preview string
-	Top     bool
+	Title      string
+	Date       string
+	Update     string
+	Author     string
+	Tags       []string
+	Categories []string
+	Topic      string
+	Draft      bool
+	Preview    string
+	Top        bool
 }
 
 type Article struct {


### PR DESCRIPTION
- add categories to tags, if tags does not contain it
- add terminate newline to content
- if file extension is .md, do not append another