### PR TITLE
make the tag sort stable even if tags has the same article count

### DIFF
--- a/build.go
+++ b/build.go
@@ -61,6 +61,9 @@ func (v Collections) Less(i, j int) bool {
 	case Archive:
 		return v[i].(Archive).Year > v[j].(Archive).Year
 	case Tag:
+		if v[i].(Tag).Count == v[j].(Tag).Count {
+			return v[i].(Tag).Name > v[j].(Tag).Name
+		}
 		return v[i].(Tag).Count > v[j].(Tag).Count
 	}
 	return false
@@ -205,9 +208,9 @@ func Build() {
 			Count:    len(tagArticles),
 			Articles: articleInfos,
 		})
-		// Sort by count
-		sort.Sort(Collections(tags))
 	}
+	// Sort by count
+	sort.Sort(Collections(tags))
 	wg.Add(1)
 	go RenderPage(tagTpl, map[string]interface{}{
 		"Total": len(articles),


### PR DESCRIPTION
The sort of tags is not stable if two tags has the same article count,
and why sort every time you get a new tag. I think sort one time is enough.

Signed-off-by: Wang Xu <gnawux@gmail.com>