### PR TITLE
解决因第三方库更换地址而造成的编译报错问题

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/InkProject/ink.go"
 	"github.com/facebookgo/symwalk"
-	"github.com/go-fsnotify/fsnotify"
+	"github.com/fsnotify/fsnotify"
 	"github.com/gorilla/websocket"
 )
 


### PR DESCRIPTION
错误位置：$GOPATH/src/github.com/InkProject/ink/serve.go:9:2: no Go files in $GOPATH/src/github.com/go-fsnotify/fsnotify;
错误解决：将github.com/go-fsnotify/fsnotify更改为github.com/fsnotify/fsnotify；