### PR TITLE
Fix some more issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ preview: {{.Preview}}
 {{- end}}
 type: {{.Type}}
 hide: {{.Hide}}
+toc: {{.Toc}}
 ---
 `
 )
@@ -111,6 +112,10 @@ func main() {
 				&cli.BoolFlag{
 					Name:  "hide",
 					Usage: "Hides the article",
+				},
+				&cli.BoolFlag{
+					Name:  "toc",
+					Usage: "Adds a table of contents to the article",
 				},
 				&cli.BoolFlag{
 					Name:  "top",
@@ -202,6 +207,7 @@ func New(c *cli.Context) {
 	top := "false"
 	postType := "post"
 	hide := "false"
+	toc := "false"
 	date := time.Now()
 
 	// Empty string values
@@ -244,6 +250,9 @@ func New(c *cli.Context) {
 	}
 	if c.Bool("hide") {
 		hide = "true"
+	}
+	if c.Bool("toc") {
+		toc = "true"
 	}
 	if c.Bool("draft") {
 		draft = "true"
@@ -299,6 +308,7 @@ func New(c *cli.Context) {
 		"Top":        top,
 		"Type":       postType,
 		"Hide":       hide,
+		"Toc":        toc,
 		"Preview":    preview,
 		"Cover":      cover,
 		"Tags":       tagString,

--- a/render.go
+++ b/render.go
@@ -66,13 +66,28 @@ func RenderArticles(tpl template.Template, articles Collections) {
 	for i := range articles {
 		currentArticle := articles[i].(Article)
 		var renderArticle = RenderArticle{currentArticle, nil, nil}
-		if i >= 1 {
-			article := articles[i-1].(Article)
-			renderArticle.Prev = &article
-		}
-		if i <= articleCount-2 {
-			article := articles[i+1].(Article)
-			renderArticle.Next = &article
+		// Only show next and prev article if it is not hidden
+		if !renderArticle.Hide {
+			if i >= 1 {
+				// Find prev unhidden article
+				for j := i - 1; j >= 0; j-- {
+					prevArticle := articles[j].(Article)
+					if !prevArticle.Hide {
+						renderArticle.Prev = &prevArticle
+						break
+					}
+				}
+			}
+			if i <= articleCount-2 {
+				// Find next unhidden article
+				for j := i + 1; j < articleCount; j++ {
+					nextArticle := articles[j].(Article)
+					if !nextArticle.Hide {
+						renderArticle.Next = &nextArticle
+						break
+					}
+				}
+			}
 		}
 		outPath := filepath.Join(publicPath, currentArticle.Link)
 		wg.Add(1)

--- a/render.go
+++ b/render.go
@@ -179,8 +179,8 @@ func RenderArticleList(rootPath string, articles Collections, tagName string) {
 			"Develop":  globalConfig.Develop,
 			"Page":     i + 1,
 			"Total":    page,
-			"Prev":     prev,
-			"Next":     next,
+			"Prev":     template.URL(filepath.ToSlash(prev)),
+			"Next":     template.URL(filepath.ToSlash(next)),
 			"TagName":  tagName,
 			"TagCount": len(articles),
 		}

--- a/template/source/ink-blog-tool-en.md
+++ b/template/source/ink-blog-tool-en.md
@@ -23,6 +23,21 @@ InkPaper is a static blog generator developed in Golang. No dependencies, cross 
 
 - Open `http://localhost:8000` in your browser to preview
 
+### Features
+- YAML format configuration
+- Markdown format articles
+- No dependencies, cross platform
+- Super fast build times
+- Continuously improving theme and typography
+- Multiple article authors support
+- Archive and tag generation
+- Real-time preview when saving
+- Offline full-text keyword search
+- $\LaTeX$ style math formula support (MathJax):
+
+$$
+\int_{-\infty}^\infty g(x) dx = \frac{1}{2\pi i} \oint_{\gamma} \frac{f(z)}{z-g(x)} dz
+$$
 ### Website Configuration
 Edit `config.yml`, use this format:
 

--- a/template/source/ink-blog-tool-en.md
+++ b/template/source/ink-blog-tool-en.md
@@ -70,6 +70,7 @@ tags: #Optional
     - Tag2
 type: post #Specify type is post or page, Optional
 hide: false #Hide article，can be accessed via URL, Optional
+toc: false #Show table of contents，Optional
 
 ---
 

--- a/template/source/ink-blog-tool.md
+++ b/template/source/ink-blog-tool.md
@@ -34,6 +34,11 @@ preview: 纸小墨（InkPaper）是一个GO语言编写的开源静态博客构�
 - 归档与标签自动生成
 - 保存时实时预览页面
 - 离线的全文关键字搜索
+- $\LaTeX$ 风格的数学公式支持（MathJax）：
+
+$$ 
+\int_{-\infty}^\infty g(x) dx = \frac{1}{2\pi i} \oint_{\gamma} \frac{f(z)}{z-g(x)} dz
+$$
 
 ### 配置网站
 编辑`config.yml`，使用如下格式：

--- a/template/source/ink-blog-tool.md
+++ b/template/source/ink-blog-tool.md
@@ -82,6 +82,7 @@ tags: #可选
     - 标签2
 type: post #指定类型为文章(post)或页面(page)，可选
 hide: false #隐藏文章，只可通过链接访问，可选
+toc: false #是否显示文章目录，可选
 
 ---
 

--- a/template/theme/_head.html
+++ b/template/theme/_head.html
@@ -51,6 +51,10 @@
     };
     var root = '{{.Site.Root}}';
 </script>
+
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
 {{if .Develop}}
 <script type="text/javascript">
     var conn, reloadTimer, connectTimer;


### PR DESCRIPTION
This PR will:

1. support `toc: true` property in article config (fix #65 and fix #94);
2. generate MathJax-friendly syntax. e.g. 
    ```markdown
    $ \LaTeX $
    $$ E = mc^2 $$
    ```
    now will be converted to
    ```html
    <span class="math inline">\[ \LaTeX \]</span>
    <span class="math display">\[ E = mc^2 \]</span>
    ```
    (close #95)
3. prevent pages with `hide: true` from being accessed by visible posts' `Prev` and `Next` (fix #108);
4. `Prev` & `Next`'s URLs are wrongly escaped on Windows in post lists filtered by tags (fix #86).
    - p.s. any file paths passed into `html/template` should NOT have backslash delimiters, which is common on Windows.