### PR TITLE
Create GitHub Action for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Build artifacts & Release
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag name for release"
+        required: false
+        default: nightly
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "stable"
+      - name: Build
+        run: sh ./release.sh
+      - if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name == 'nightly')
+        name: Release Nightly
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release/ink*
+          prerelease: true
+          tag_name: nightly
+          name: Nightly build
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+      - if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release/ink*
+          prerelease: false
+          name: Release ${{ github.ref }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/release.sh
+++ b/release.sh
@@ -5,13 +5,13 @@
 build () {
   echo "building for $1 $2..."
   suffix=""
-  if [ $1 == "windows" ]
+  if [ $1 = "windows" ]
   then
     suffix=".exe"
   fi
   GOOS=$1 GOARCH=$2 go build -o release/ink$suffix
   cd release
-  if [ $1 == "linux" ]
+  if [ $1 = "linux" ]
   then
     tar cvf - blog/* ink$suffix | gzip -9 - > ink_$1_$2.tar.gz
   else
@@ -28,8 +28,15 @@ rsync -av template/* release/blog --delete --exclude public --exclude theme/node
 
 build linux 386
 build linux amd64
+build linux arm
+build linux arm64
+
 build darwin amd64
+build darwin arm64
+
 build windows 386
 build windows amd64
+build windows arm
+build windows arm64
 
 rm -rf release/blog


### PR DESCRIPTION
This PR will:

1. fix a syntax typo in `release.sh` (ref: <https://linux.die.net/man/1/test>);
2. add more build targets to `release.sh` (It covers all major desktop platforms now, uhh?);
3. close #140 , the action configuration mainly from [here](https://github.com/dragonflyoss/image-service/blob/master/.github/workflows/release.yml) and [here](https://github.com/neovim/neovim/blob/nightly/.github/workflows/release.yml).

A release example: <https://github.com/w568w/inkstone/releases/tag/nightly>.